### PR TITLE
Add style to the asciidoc callout from source codeblock

### DIFF
--- a/preview-site-src/index.adoc
+++ b/preview-site-src/index.adoc
@@ -276,3 +276,20 @@ http://packages.couchbase.com/clients/kafka/3.2.3/kafka-connect-couchbase-3.2.3.
 == `spec.volumeClaimTemplates.metadata`
 
 This section demonstrates what happens when the section title does not have any natural wrap opportunities.
+
+== Callouts
+
+.XML element
+[source,xml,linenums]
+----
+<api-platform-gw:api
+  apiName="${apiName}" // <1>
+  version="${apiVersion}" //<2>
+  flowRef="proxy" //<3>
+  apikitRef="api-config"/> //<4>
+----
+
+<1> Configure the `${apiName}` with the UUID, which is the group ID and the Exchange asset ID assigned to your API by API Manager.
+<2> Configure the `${apiVersion}` with the API Version, which is the version name and the instance ID or the label assigned to your API by API Manager.
+<3> Set the `flowRef` element to point to the flow that you want to pair to the API in API Manager.
+<4> If you use APIKit and you would like to apply policies at a resource level, you must set this value. Otherwise said policies won't work at resource level.

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -16,43 +16,44 @@
     }
   }
 
-  & .conum[data-value] {
-    align-items: center;
-    border: 1px solid;
-    border-color: #11a9e0;
-    border-radius: 100%;
-    display: -webkit-inline-box;
-    display: -ms-inline-flexbox;
-    display: inline-flex;
-    font-family: Roboto, sans-serif;
-    font-size: .75rem;
+  /* numbered callouts from codeblocks */
+  & .conum {
+    background: var(--tertiary);
+    border: 1px solid var(--aluminum-3);
+    border-radius: 4px;
+    font-family: var(--sans-serif);
+    font-size: 12px;
     font-style: normal;
-    height: 1rem;
-    justify-content: center;
-    vertical-align: text-bottom;
-    width: 1rem;
+    font-weight: --weight-bold;
+    padding: 0 5px;
+
+    &::after {
+      content: attr(data-value);
+    }
+
+    & + b {
+      display: none;
+    }
   }
-  & .conum[data-value]::after {
-    content: attr(data-value);
+
+  /* collouts within the codeblock */
+  & pre .conum {
+    box-shadow: 0 2px 6px var(--aluminum-3);
   }
-  & .conum[data-value] + b {
-    display: none;
-  }
-  & pre .conum[data-value] {
-    background-color: #f8f8f2;
-    border-color: #f8f8f2;
-    color: #151514;
-  }
+
+  /* references within codeblock */
   & .colist {
-    margin-top: .5rem;
-  }
-  & .colist td:first-of-type {
-    line-height: 1.4;
-    padding: 0 .5rem;
-    vertical-align: top;
-  }
-  & .colist td:last-of-type {
-    padding: 0;
+
+    /* numbers */
+    & td:first-of-type {
+      padding: 0 10px
+      vertical-align: top;
+    }
+
+    /* content */
+    & td:last-of-type {
+      padding: 0;
+    }
   }
 
   /* default spacing */

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -46,7 +46,7 @@
 
     /* numbers */
     & td:first-of-type {
-      padding: 0 10px
+      padding: 0 10px;
       vertical-align: top;
     }
 

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -29,6 +29,10 @@
 
     &::after {
       content: attr(data-value);
+      -webkit-user-select: none; /* Safari */
+      -moz-user-select: none; /* Firefox */
+      -ms-user-select: none; /* IE10+/Edge */
+      user-select: none; /* Standard */
     }
 
     & + b {

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -16,6 +16,45 @@
     }
   }
 
+  & .conum[data-value] {
+    align-items: center;
+    border: 1px solid;
+    border-color: #11a9e0;
+    border-radius: 100%;
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    font-family: Roboto, sans-serif;
+    font-size: .75rem;
+    font-style: normal;
+    height: 1rem;
+    justify-content: center;
+    vertical-align: text-bottom;
+    width: 1rem;
+  }
+  & .conum[data-value]::after {
+    content: attr(data-value);
+  }
+  & .conum[data-value] + b {
+    display: none;
+  }
+  & pre .conum[data-value] {
+    background-color: #f8f8f2;
+    border-color: #f8f8f2;
+    color: #151514;
+  }
+  & .colist {
+    margin-top: .5rem;
+  }
+  & .colist td:first-of-type {
+    line-height: 1.4;
+    padding: 0 .5rem;
+    vertical-align: top;
+  }
+  & .colist td:last-of-type {
+    padding: 0;
+  }
+
   /* default spacing */
   & > h1:first-child {
     padding-top: var(--lg);


### PR DESCRIPTION
This PR allows us to customize the numbered callouts from codeblocks, improving our current style from this:
<img width="690" alt="screen shot 2019-01-24 at 8 36 57 am" src="https://user-images.githubusercontent.com/16763154/51676380-37f73400-1fb5-11e9-8718-ba3d4c5d6abd.png">

To this:

<img width="615" alt="screen shot 2019-01-24 at 8 36 27 am" src="https://user-images.githubusercontent.com/16763154/51676393-404f6f00-1fb5-11e9-85e7-39bba20570c8.png">
